### PR TITLE
chore: fix lint and update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # The @googleapis/api-pubsublite is the default owner for changes in this repo
 *                       @googleapis/yoshi-java @googleapis/api-pubsub
-**/*.java               @googleapis/api-pubsub @orabbit
+**/*.java               @googleapis/api-pubsub @samarthsingal
 
 # The java-samples-reviewers team is the default owner for samples changes
 # samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -51,7 +51,8 @@ test)
     RETURN_CODE=$?
     ;;
 lint)
-    mvn com.coveo:fmt-maven-plugin:check
+    mvn com.coveo:fmt-maven-plugin:format
+    cat /home/runner/work/java-pubsub-group-kafka-connector/java-pubsub-group-kafka-connector/src/test/java/com/google/pubsublite/kafka/sink/PubSubLiteSinkTaskTest.java
     RETURN_CODE=$?
     ;;
 javadoc)
@@ -83,7 +84,7 @@ bash .kokoro/coerce_logs.sh
 if [[ "${ENABLE_BUILD_COP}" == "true" ]]
 then
     chmod +x ${KOKORO_GFILE_DIR}/linux_amd64/flakybot
-    ${KOKORO_GFILE_DIR}/linux_amd64/flakybot -repo=googleapis/java-pubsublite-spark
+    ${KOKORO_GFILE_DIR}/linux_amd64/flakybot -repo=googleapis/java-pubsub-group-kafka-connector
 fi
 
 echo "exiting with ${RETURN_CODE}"

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -51,8 +51,7 @@ test)
     RETURN_CODE=$?
     ;;
 lint)
-    mvn com.coveo:fmt-maven-plugin:format
-    cat /home/runner/work/java-pubsub-group-kafka-connector/java-pubsub-group-kafka-connector/src/test/java/com/google/pubsublite/kafka/sink/PubSubLiteSinkTaskTest.java
+    mvn com.coveo:fmt-maven-plugin:check
     RETURN_CODE=$?
     ;;
 javadoc)

--- a/src/main/java/com/google/pubsub/kafka/source/AckBatchingSubscriber.java
+++ b/src/main/java/com/google/pubsub/kafka/source/AckBatchingSubscriber.java
@@ -38,7 +38,7 @@ public class AckBatchingSubscriber implements CloudPubSubSubscriber {
   private static class IdsAndFuture {
     Collection<String> ids;
     SettableApiFuture<Empty> future;
-  };
+  }
 
   private final CloudPubSubSubscriber underlying;
 

--- a/src/test/java/com/google/pubsublite/kafka/sink/PubSubLiteSinkTaskTest.java
+++ b/src/test/java/com/google/pubsublite/kafka/sink/PubSubLiteSinkTaskTest.java
@@ -264,14 +264,10 @@ public class PubSubLiteSinkTaskTest {
             .put(Constants.KAFKA_TOPIC_HEADER, ByteString.copyFromUtf8(KAFKA_TOPIC))
             .put(Constants.KAFKA_PARTITION_HEADER, ByteString.copyFromUtf8(Integer.toString(4)))
             .build();
-    Message expectedBase =
+    Message message1 =
         Message.builder()
             .setKey(ByteString.copyFromUtf8(KAFKA_MESSAGE_KEY1))
             .setData(KAFKA_MESSAGE1)
-            .build();
-    Message message1 =
-        expectedBase
-            .toBuilder()
             .setEventTime(Timestamps.fromMillis(50000))
             .setAttributes(
                 ImmutableListMultimap.<String, ByteString>builder()
@@ -283,8 +279,9 @@ public class PubSubLiteSinkTaskTest {
                     .build())
             .build();
     Message message2 =
-        expectedBase
-            .toBuilder()
+        Message.builder()
+            .setKey(ByteString.copyFromUtf8(KAFKA_MESSAGE_KEY1))
+            .setData(KAFKA_MESSAGE1)
             .setEventTime(Timestamps.fromMillis(50001))
             .setAttributes(
                 ImmutableListMultimap.<String, ByteString>builder()
@@ -296,8 +293,9 @@ public class PubSubLiteSinkTaskTest {
                     .build())
             .build();
     Message message3 =
-        expectedBase
-            .toBuilder()
+        Message.builder()
+            .setKey(ByteString.copyFromUtf8(KAFKA_MESSAGE_KEY1))
+            .setData(KAFKA_MESSAGE1)
             .setAttributes(
                 ImmutableListMultimap.<String, ByteString>builder()
                     .putAll(attributesBase)
@@ -343,14 +341,10 @@ public class PubSubLiteSinkTaskTest {
             .put(Constants.KAFKA_TOPIC_HEADER, ByteString.copyFromUtf8(KAFKA_TOPIC))
             .put(Constants.KAFKA_PARTITION_HEADER, ByteString.copyFromUtf8(Integer.toString(4)))
             .build();
-    Message expectedBase =
+    Message message1 =
         Message.builder()
             .setKey(ByteString.copyFromUtf8(KAFKA_MESSAGE_KEY1))
             .setData(KAFKA_MESSAGE1)
-            .build();
-    Message message1 =
-        expectedBase
-            .toBuilder()
             .setEventTime(Timestamps.fromMillis(50000))
             .setAttributes(
                 ImmutableListMultimap.<String, ByteString>builder()
@@ -363,8 +357,9 @@ public class PubSubLiteSinkTaskTest {
                     .build())
             .build();
     Message message2 =
-        expectedBase
-            .toBuilder()
+        Message.builder()
+            .setKey(ByteString.copyFromUtf8(KAFKA_MESSAGE_KEY1))
+            .setData(KAFKA_MESSAGE1)
             .setEventTime(Timestamps.fromMillis(50001))
             .setAttributes(
                 ImmutableListMultimap.<String, ByteString>builder()


### PR DESCRIPTION
- get rid of `expectedBase` because `mvn com.coveo:fmt-maven-plugin:format` and `mvn com.coveo:fmt-maven-plugin:check` kept changing the format back and forth
- update codeowners to @samarthsingal 
- fix a copy paste error 

@samarthsingal would you fix the deps issues?