### PR TITLE
chore: support windows longpaths

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,8 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
+    - name: Support longpaths
+      run: git config --system core.longpaths true
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
This seems required by #27 

Checkout a successful merge from another repo: https://github.com/googleapis/java-pubsublite/pull/1173/files