### PR TITLE
chore: format owlbot.py

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -18,5 +18,5 @@ import synthtool.languages.java as java
 
 java.common_templates(excludes=[
     # Exclude Java 17 in ci
-    '.github/workflows/ci.yaml',
+    ".github/workflows/ci.yaml",
 ])


### PR DESCRIPTION
Fix `Step #5: json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 19 column 1 (char 955)
Finished Step #5` reported in https://pantheon.corp.google.com/cloud-build/builds;region=global/8b198376-2aa6-464a-8f31-6b1fed276322?project=repo-automation-bots&pli=1&jsmode=o&mods=local_coliseum

Unblock #27 