### PR TITLE
chore: reformat .repo-metadata.json and update owlbot.py

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,9 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/api-pubsublite is the default owner for changes in this repo
+# The @googleapis/api-pubsub is the default owner for changes in this repo
 *                       @googleapis/yoshi-java @googleapis/api-pubsub
-**/*.java               @googleapis/api-pubsub @samarthsingal
+**/*.java               @googleapis/api-pubsub
 
 # The java-samples-reviewers team is the default owner for samples changes
-# samples/**/*.java       @googleapis/java-samples-reviewers
+samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,14 +10,14 @@ Thanks for stopping by to let us know something could be better!
 
 Please run down the following list and make sure you've tried the usual "quick fixes":
 
-  - Search the issues already opened: https://github.com/googleapis/java-pubsublite-spark/issues
+  - Search the issues already opened: https://github.com/googleapis/java-pubsub-group-kafka-connector/issues
   - Check for answers on StackOverflow: http://stackoverflow.com/questions/tagged/google-cloud-platform
 
 If you are still having issues, please include as much information as possible:
 
 #### Environment details
 
-1. Specify the API at the beginning of the title. For example, "Pub/Sub: ...").
+1. Specify the API at the beginning of the title. For example, "BigQuery: ...").
    General, Core, and Other are also allowed as types
 2. OS type and version:
 3. Java version:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
-- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-pubsublite-spark/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
+- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-pubsub-group-kafka-connector/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
 - [ ] Ensure the tests and linter pass
 - [ ] Code coverage does not decrease (if any source code was changed)
 - [ ] Appropriate docs were updated (if necessary)

--- a/.github/auto-label.yaml
+++ b/.github/auto-label.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -4,4 +4,4 @@ assign_prs_by:
 - labels:
   - samples
   to:
-  - googleapis/api-pubsub
+  - googleapis/java-samples-reviewers

--- a/.kokoro/coerce_logs.sh
+++ b/.kokoro/coerce_logs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,3 +56,5 @@ function retry_with_backoff {
 function now() { date +"%Y-%m-%d %H:%M:%S" | tr -d '\n'; }
 function msg() { println "$*" >&2; }
 function println() { printf '%s\n' "$(now) $*"; }
+
+## Helper comment to trigger updated repo dependency release

--- a/.kokoro/dependencies.sh
+++ b/.kokoro/dependencies.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.kokoro/populate-secrets.sh
+++ b/.kokoro/populate-secrets.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.kokoro/release/common.sh
+++ b/.kokoro/release/common.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.kokoro/release/drop.sh
+++ b/.kokoro/release/drop.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.kokoro/release/promote.sh
+++ b/.kokoro/release/promote.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.kokoro/release/publish_javadoc.sh
+++ b/.kokoro/release/publish_javadoc.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ python3 -m pip install gcp-docuploader
 # compile all packages
 mvn clean install -B -q -DskipTests=true
 
-export NAME=pubsublite-spark-sql-streaming
+export NAME=pubsub-group-kafka-connector
 export VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
 
 # build the docs

--- a/.kokoro/release/publish_javadoc11.sh
+++ b/.kokoro/release/publish_javadoc11.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.kokoro/release/snapshot.sh
+++ b/.kokoro/release/snapshot.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ retry_with_backoff 3 10 \
   mvn clean deploy -B \
     --settings ${MAVEN_SETTINGS_FILE} \
     -DskipTests=true \
+    -Dclirr.skip=true \
     -DperformRelease=true \
     -Dgpg.executable=gpg \
     -Dgpg.passphrase=${GPG_PASSPHRASE} \

--- a/.kokoro/trampoline.sh
+++ b/.kokoro/trampoline.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -15,5 +15,5 @@
   "api_id": "pubsub.googleapis.com",
   "library_type": "AGENT",
   "transport": "grpc",
-  "requires_billing": true,
+  "requires_billing": true
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ mvn clean verify
 ### Running Integration tests
 
 To include integration tests when building the project, you need access to
-a GCP Project with a valid service account.
+a GCP Project with a valid service account. 
 
 For instructions on how to generate a service account and corresponding
 credentials JSON see: [Creating a Service Account][1].
@@ -62,9 +62,9 @@ The samples must be separate from the primary project for a few reasons:
    selectively exclude samples from a build run.
 2. Many code samples depend on external GCP services and need
    credentials to access the service.
-3. Code samples are not released as Maven artifacts and must be excluded from
+3. Code samples are not released as Maven artifacts and must be excluded from 
    release builds.
-
+   
 ### Building
 
 ```bash

--- a/owlbot.py
+++ b/owlbot.py
@@ -17,6 +17,42 @@
 import synthtool.languages.java as java
 
 java.common_templates(excludes=[
-    # Exclude Java 17 in ci
+    # Prevent owlbot from adding snippet bot.
+    ".github/snippet-bot.yml",
+    # Exclude Java 17 in ci.
     ".github/workflows/ci.yaml",
+    ".github/workflows/samples.yaml",
+    # Use customized Kokoro build.sh.
+    ".kokoro/build.sh",
+    # Exclude these Kokoro build configs from owlbot updates.
+    ".kokoro/continuous/java8.cfg",
+    ".kokoro/nightly/integration.cfg",
+    ".kokoro/nightly/java11-integration.cfg",
+    ".kokoro/nightly/java11.cfg",
+    ".kokoro/nightly/java7.cfg",
+    ".kokoro/nightly/java8-osx.cfg",
+    ".kokoro/nightly/java8-win.cfg",
+    ".kokoro/nightly/java8.cfg",
+    ".kokoro/nightly/samples.cfg",
+    ".kokoro/presubmit/clirr.cfg",
+    ".kokoro/presubmit/dependencies.cfg",
+    ".kokoro/presubmit/graalvm-native-17.cfg",
+    ".kokoro/presubmit/graalvm-native.cfg",
+    ".kokoro/presubmit/integration.cfg",
+    ".kokoro/presubmit/java11.cfg",
+    ".kokoro/presubmit/java7.cfg",
+    ".kokoro/presubmit/java8-osx.cfg",
+    ".kokoro/presubmit/java8-win.cfg",
+    ".kokoro/presubmit/java8.cfg",
+    ".kokoro/presubmit/linkage-monitor.cfg",
+    ".kokoro/presubmit/lint.cfg",
+    ".kokoro/presubmit/samples.cfg",
+    ".kokoro/readme.sh",
+    # Exclude owlbot from README.
+    "README.md",
+    # Exclude owlbot from adding samples dir.
+    "samples/install-without-bom/pom.xml",
+    "samples/pom.xml",
+    "samples/snapshot/pom.xml",
+    "samples/snippets/pom.xml",
 ])

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,74 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
-  ]
+    ":separateMajorReleases",
+    ":combinePatchMinorReleases",
+    ":ignoreUnstable",
+    ":prImmediately",
+    ":updateNotScheduled",
+    ":automergeDisabled",
+    ":ignoreModulesAndTests",
+    ":maintainLockFilesDisabled",
+    ":autodetectPinVersions"
+  ],
+  "packageRules": [
+    {
+      "packagePatterns": [
+        "^com.google.guava:"
+      ],
+      "versionScheme": "docker"
+    },
+    {
+      "packagePatterns": [
+        "*"
+      ],
+      "semanticCommitType": "deps",
+      "semanticCommitScope": null
+    },
+    {
+      "packagePatterns": [
+        "^org.apache.maven",
+        "^org.jacoco:",
+        "^org.codehaus.mojo:",
+        "^org.sonatype.plugins:",
+        "^com.coveo:",
+        "^com.google.cloud:google-cloud-shared-config"
+      ],
+      "semanticCommitType": "build",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "packagePatterns": [
+        "^com.google.cloud:pubsub-group-kafka-connector",
+        "^com.google.cloud:libraries-bom",
+        "^com.google.cloud.samples:shared-configuration"
+      ],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "packagePatterns": [
+        "^junit:junit",
+        "^com.google.truth:truth",
+        "^org.mockito:mockito-core",
+        "^org.objenesis:objenesis",
+        "^com.google.cloud:google-cloud-conformance-tests"
+      ],
+      "semanticCommitType": "test",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "packagePatterns": [
+        "^com.google.cloud:google-cloud-"
+      ],
+      "ignoreUnstable": false
+    },
+    {
+      "packagePatterns": [
+        "^com.fasterxml.jackson.core"
+      ],
+      "groupName": "jackson dependencies"
+    }
+  ],
+  "semanticCommits": true,
+  "dependencyDashboard": true
 }


### PR DESCRIPTION
A comma in .repo-metadata.json was causing Owlbot to yell at me: https://pantheon.corp.google.com/cloud-build/builds;region=global/e4036c66-2ef9-4b89-ba9d-0f1d45eb18f7?jsmode=o&mods=local_coliseum&project=repo-automation-bots

- Most of the changes are made by running `python owlbot.py` after I added the exclusions. 
- Exclusion in `owlbot.py` are some files / directories that we want to manage on our own because of the nature of this repo (not a client library and no samples but we will have integration tests).