### PR TITLE
chore: check env vars are populated

### DIFF
--- a/.kokoro/continuous/integration.cfg
+++ b/.kokoro/continuous/integration.cfg
@@ -28,5 +28,5 @@ env_vars: {
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "java-it-service-account"
+  value: "java-it-service-account,java-docs-samples-service-account,java-pubsub-group-kafka-connector-secrets"
 }

--- a/.kokoro/nightly/integration.cfg
+++ b/.kokoro/nightly/integration.cfg
@@ -33,5 +33,5 @@ env_vars: {
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "java-it-service-account"
+  value: "java-it-service-account,java-docs-samples-service-account,java-pubsub-group-kafka-connector-secrets"
 }

--- a/.kokoro/presubmit/integration.cfg
+++ b/.kokoro/presubmit/integration.cfg
@@ -21,9 +21,7 @@ env_vars: {
   value: "secret_manager/java-docs-samples-service-account"
 }
 
-# Re-use env vars from java-pubsublite-spark-samples-secrets to obtain
-# project number and bucket name for IT.
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "java-docs-samples-service-account,java-pubsublite-spark-samples-secrets"
+  value: "java-docs-samples-service-account"
 }

--- a/.kokoro/presubmit/integration.cfg
+++ b/.kokoro/presubmit/integration.cfg
@@ -23,5 +23,5 @@ env_vars: {
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "java-docs-samples-service-account"
+  value: "java-docs-samples-service-account,java-pubsub-group-kafka-connector-secrets"
 }

--- a/src/test/java/it/Base.java
+++ b/src/test/java/it/Base.java
@@ -48,8 +48,7 @@ public class Base {
 
   private static final GoogleLogger log = GoogleLogger.forEnclosingClass();
 
-  // TODO: System.getenv("BUCKET_NAME")
-  private static final String bucketName = "pubsublite-it";
+  private static final String bucketName = System.getenv("BUCKET_NAME");
   protected static final String runId = UUID.randomUUID().toString().substring(0, 8);
   protected String mavenHome;
   protected String workingDir;

--- a/src/test/java/it/StandaloneIT.java
+++ b/src/test/java/it/StandaloneIT.java
@@ -57,6 +57,7 @@ public class StandaloneIT extends Base {
 
   @BeforeClass
   public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
     requireEnvVar("GOOGLE_CLOUD_PROJECT_NUMBER");
     requireEnvVar("BUCKET_NAME");
   }

--- a/src/test/java/it/StandaloneIT.java
+++ b/src/test/java/it/StandaloneIT.java
@@ -1,5 +1,7 @@
 package it;
 
+import static junit.framework.TestCase.assertNotNull;
+
 import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.compute.v1.InstanceTemplatesClient;
 import com.google.cloud.compute.v1.InstancesClient;
@@ -16,6 +18,7 @@ import java.io.PrintStream;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -27,8 +30,7 @@ public class StandaloneIT extends Base {
   private static final GoogleLogger log = GoogleLogger.forEnclosingClass();
 
   private static final String projectId = System.getenv("GOOGLE_CLOUD_PROJECT");
-  // TODO: System.getenv("GOOGLE_CLOUD_PROJECT_NUMBER");
-  private static final String projectNumber = "779844219229";
+  private static final String projectNumber = System.getenv("GOOGLE_CLOUD_PROJECT_NUMBER");
   private static final String sourceTopicId = "source-topic-" + runId;
   private static final String sourceSubscriptionId = "source-subscription-" + runId;
   private static final String sinkTopicId = "sink-topic-" + runId;
@@ -45,7 +47,19 @@ public class StandaloneIT extends Base {
   private static final SubscriptionName sinkSubscriptionName =
       SubscriptionName.of(projectId, sinkSubscriptionId);
 
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+  }
+
   @Rule public Timeout globalTimeout = Timeout.seconds(600); // 10 minute timeout
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT_NUMBER");
+    requireEnvVar("BUCKET_NAME");
+  }
 
   @Before
   public void setUp() throws Exception {


### PR DESCRIPTION
https://github.com/googleapis/java-pubsub-group-kafka-connector/blob/3c673929a3597fd5a7380eac8b91eaf204e91d72/.kokoro/populate-secrets.sh#L28

is ran from 

https://github.com/googleapis/java-pubsub-group-kafka-connector/blob/3c673929a3597fd5a7380eac8b91eaf204e91d72/.kokoro/trampoline.sh#L25

and `trampoline.sh` is triggered in 

https://github.com/googleapis/java-pubsub-group-kafka-connector/blob/3c673929a3597fd5a7380eac8b91eaf204e91d72/.kokoro/presubmit/common.cfg#L15

The contents of the secret `java-pubsub-group-kafka-connector-secrets` are sourced by

https://github.com/googleapis/java-pubsub-group-kafka-connector/blob/3c673929a3597fd5a7380eac8b91eaf204e91d72/.kokoro/build.sh#L64

and populates the env vars needed for the ITs