### PR TITLE
chore: match nightly build config with presubmit

### DIFF
--- a/.kokoro/nightly/integration.cfg
+++ b/.kokoro/nightly/integration.cfg
@@ -28,10 +28,10 @@ env_vars: {
 
 env_vars: {
   key: "GOOGLE_APPLICATION_CREDENTIALS"
-  value: "secret_manager/java-it-service-account"
+  value: "secret_manager/java-docs-samples-service-account"
 }
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "java-it-service-account,java-docs-samples-service-account,java-pubsub-group-kafka-connector-secrets"
+  value: "java-docs-samples-service-account,java-pubsub-group-kafka-connector-secrets"
 }


### PR DESCRIPTION
Nightly tests failed with `403 Forbidden xxx@xxx.iam.gserviceaccount.com does not have storage.objects.create access to the Google Cloud Storage object.`. Updating nightly build config to match presubmit build config.

https://fusion2.corp.google.com/invocations/25f15abe-d1db-463d-a211-b9208ebf65c0/targets/cloud-devrel%2Fclient-libraries%2Fjava%2Fjava-pubsub-group-kafka-connector%2Fnightly%2Fintegration