### PR TITLE
fix: update version in pom and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ locally in standalone mode (single process).
 
 ### Acquire the connector
 
-A pre-built uber-jar is available for download on the
-[releases page](https://github.com/googleapis/java-pubsub-group-kafka-connector/releases).
+The connector is available from [Maven Central repository](https://search.maven.org/artifact/com.google.cloud/pubsub-group-kafka-connector).
+Select the latest version of the connector, then download "jar" from the
+**Downloads** dropdown menu.
 
 You can also [build](#build-the-connector) the connector from head.
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.google.cloud</groupId>
   <artifactId>pubsub-group-kafka-connector</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Pub/Sub Group Kafka Connector</name>
   <url>https://github.com/googleapis/java-pubsub-group-kafka-connector</url>


### PR DESCRIPTION
For some reason, both bot-opened https://github.com/googleapis/java-pubsub-group-kafka-connector/pull/138 and https://github.com/googleapis/java-pubsub-group-kafka-connector/pull/139 never updated `pom.xml`, causing the versions in `versions.txt` to deviate from the version in `pom.xml`. 

