### PR TITLE
fix: Cleanup CPS source subscription in tearDown()

### DIFF
--- a/src/test/java/it/StandaloneIT.java
+++ b/src/test/java/it/StandaloneIT.java
@@ -362,6 +362,10 @@ public class StandaloneIT extends Base {
           () -> {
             subscriptionAdminClient.deleteSubscription(cpsSinkSubscriptionName);
           });
+      notFoundIgnoredClosureRunner.apply(
+          () -> {
+            subscriptionAdminClient.deleteSubscription(cpsSourceSubscriptionName);
+          });
       log.atInfo().log("Deleted CPS subscriptions.");
     }
 


### PR DESCRIPTION
Cleans up CPS source subscription which was earlier missed