### PR TITLE
chore(fix): ignore clirr in javadoc publish

### DIFF
--- a/.kokoro/release/publish_javadoc.sh
+++ b/.kokoro/release/publish_javadoc.sh
@@ -31,7 +31,7 @@ pushd $(dirname "$0")/../../
 python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 
 # compile all packages
-mvn clean install -B -q -DskipTests=true
+mvn clean install -B -q -DskipTests=true -Dclirr.skip=true
 
 export NAME=pubsub-group-kafka-connector
 export VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)

--- a/.kokoro/release/publish_javadoc11.sh
+++ b/.kokoro/release/publish_javadoc11.sh
@@ -31,7 +31,7 @@ pushd $(dirname "$0")/../../
 python3 -m pip install --require-hashes -r .kokoro/requirements.txt
 
 # compile all packages
-mvn clean install -B -q -DskipTests=true
+mvn clean install -B -q -DskipTests=true -Dclirr.skip=true
 
 export NAME=pubsub-group-kafka-connector
 export VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)

--- a/owlbot.py
+++ b/owlbot.py
@@ -48,6 +48,8 @@ java.common_templates(excludes=[
     ".kokoro/presubmit/lint.cfg",
     ".kokoro/presubmit/samples.cfg",
     ".kokoro/readme.sh",
+    ".kokoro/release/publish_javadoc.sh",
+    ".kokoro/release/publish_javadoc11.sh",
     # Exclude owlbot from README.
     "README.md",
     # Exclude owlbot from adding samples dir.


### PR DESCRIPTION
This is a workaround for `publish_javadoc11.sh` error `Execution default-cli of goal org.codehaus.mojo:clirr-maven-plugin:2.8:check failed: Invalid byte tag in constant pool: 19`. 