### PR TITLE
fix: report connector package version instead of kafka connect version

### DIFF
--- a/src/main/java/com/google/pubsub/kafka/common/Version.java
+++ b/src/main/java/com/google/pubsub/kafka/common/Version.java
@@ -16,16 +16,16 @@
 package com.google.pubsub.kafka.common;
 
 public class Version {
-    private static String version = "unknown";
+  private static String version = "unknown";
 
-    static {
-        String implementationVersion = Version.class.getPackage().getImplementationVersion();
-        if (implementationVersion != null) {
-            version = implementationVersion;
-        }
+  static {
+    String implementationVersion = Version.class.getPackage().getImplementationVersion();
+    if (implementationVersion != null) {
+      version = implementationVersion;
     }
+  }
 
-    public static String version() {
-        return version;
-    }
+  public static String version() {
+    return version;
+  }
 }

--- a/src/main/java/com/google/pubsub/kafka/common/Version.java
+++ b/src/main/java/com/google/pubsub/kafka/common/Version.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.pubsub.kafka.common;
+
+public class Version {
+    private static String version = "unknown";
+
+    static {
+        String implementationVersion = Version.class.getPackage().getImplementationVersion();
+        if (implementationVersion != null) {
+            version = implementationVersion;
+        }
+    }
+
+    public static String version() {
+        return version;
+    }
+}

--- a/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
+++ b/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
@@ -16,13 +16,12 @@
 package com.google.pubsub.kafka.sink;
 
 import com.google.pubsub.kafka.common.ConnectorUtils;
+import com.google.pubsub.kafka.common.Version;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.google.pubsub.kafka.common.Version;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;

--- a/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
+++ b/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
@@ -21,11 +21,12 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.google.pubsub.kafka.common.Version;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.slf4j.Logger;
@@ -117,7 +118,7 @@ public class CloudPubSubSinkConnector extends SinkConnector {
 
   @Override
   public String version() {
-    return AppInfoParser.getVersion();
+    return Version.version();
   }
 
   @Override

--- a/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
+++ b/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
@@ -21,6 +21,7 @@ import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.pubsub.kafka.common.ConnectorCredentialsProvider;
 import com.google.pubsub.kafka.common.ConnectorUtils;
+import com.google.pubsub.kafka.common.Version;
 import com.google.pubsub.v1.GetSubscriptionRequest;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +32,6 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceConnector;
@@ -130,7 +130,7 @@ public class CloudPubSubSourceConnector extends SourceConnector {
 
   @Override
   public String version() {
-    return AppInfoParser.getVersion();
+    return Version.version();
   }
 
   @Override

--- a/src/main/java/com/google/pubsublite/kafka/common/Version.java
+++ b/src/main/java/com/google/pubsublite/kafka/common/Version.java
@@ -16,16 +16,16 @@
 package com.google.pubsublite.kafka.common;
 
 public class Version {
-    private static String version = "unknown";
+  private static String version = "unknown";
 
-    static {
-        String implementationVersion = Version.class.getPackage().getImplementationVersion();
-        if (implementationVersion != null) {
-            version = implementationVersion;
-        }
+  static {
+    String implementationVersion = Version.class.getPackage().getImplementationVersion();
+    if (implementationVersion != null) {
+      version = implementationVersion;
     }
+  }
 
-    public static String version() {
-        return version;
-    }
+  public static String version() {
+    return version;
+  }
 }

--- a/src/main/java/com/google/pubsublite/kafka/common/Version.java
+++ b/src/main/java/com/google/pubsublite/kafka/common/Version.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.pubsublite.kafka.common;
+
+public class Version {
+    private static String version = "unknown";
+
+    static {
+        String implementationVersion = Version.class.getPackage().getImplementationVersion();
+        if (implementationVersion != null) {
+            version = implementationVersion;
+        }
+    }
+
+    public static String version() {
+        return version;
+    }
+}

--- a/src/main/java/com/google/pubsublite/kafka/sink/PubSubLiteSinkConnector.java
+++ b/src/main/java/com/google/pubsublite/kafka/sink/PubSubLiteSinkConnector.java
@@ -18,8 +18,9 @@ package com.google.pubsublite.kafka.sink;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import com.google.pubsublite.kafka.common.Version;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
 
@@ -28,7 +29,7 @@ public class PubSubLiteSinkConnector extends SinkConnector {
 
   @Override
   public String version() {
-    return AppInfoParser.getVersion();
+    return Version.version();
   }
 
   @Override

--- a/src/main/java/com/google/pubsublite/kafka/sink/PubSubLiteSinkConnector.java
+++ b/src/main/java/com/google/pubsublite/kafka/sink/PubSubLiteSinkConnector.java
@@ -15,11 +15,10 @@
  */
 package com.google.pubsublite.kafka.sink;
 
+import com.google.pubsublite.kafka.common.Version;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import com.google.pubsublite.kafka.common.Version;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;

--- a/src/main/java/com/google/pubsublite/kafka/sink/PubSubLiteSinkTask.java
+++ b/src/main/java/com/google/pubsublite/kafka/sink/PubSubLiteSinkTask.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -54,7 +53,7 @@ public class PubSubLiteSinkTask extends SinkTask {
 
   @Override
   public String version() {
-    return AppInfoParser.getVersion();
+    return new PubSubLiteSinkConnector().version();
   }
 
   @Override

--- a/src/main/java/com/google/pubsublite/kafka/source/PubSubLiteSourceConnector.java
+++ b/src/main/java/com/google/pubsublite/kafka/source/PubSubLiteSourceConnector.java
@@ -15,11 +15,10 @@
  */
 package com.google.pubsublite.kafka.source;
 
+import com.google.pubsublite.kafka.common.Version;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import com.google.pubsublite.kafka.common.Version;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.source.SourceConnector;

--- a/src/main/java/com/google/pubsublite/kafka/source/PubSubLiteSourceConnector.java
+++ b/src/main/java/com/google/pubsublite/kafka/source/PubSubLiteSourceConnector.java
@@ -18,8 +18,9 @@ package com.google.pubsublite.kafka.source;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import com.google.pubsublite.kafka.common.Version;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.source.SourceConnector;
 
@@ -29,7 +30,7 @@ public class PubSubLiteSourceConnector extends SourceConnector {
 
   @Override
   public String version() {
-    return AppInfoParser.getVersion();
+    return Version.version();
   }
 
   @Override

--- a/src/main/java/com/google/pubsublite/kafka/source/PubSubLiteSourceTask.java
+++ b/src/main/java/com/google/pubsublite/kafka/source/PubSubLiteSourceTask.java
@@ -19,7 +19,6 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 
@@ -39,7 +38,7 @@ public class PubSubLiteSourceTask extends SourceTask {
 
   @Override
   public String version() {
-    return AppInfoParser.getVersion();
+    return new PubSubLiteSourceConnector().version();
   }
 
   @Override


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-pubsub-group-kafka-connector/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #249 

Referenced from https://github.com/confluentinc/kafka-connect-bigquery/blob/986b1be57add8bc842f31168c308fd15ccf05bf4/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/Version.java#L30

I believe it's okay to copy that code because of Apache License. Let me know if there's a problem with it.

