### PR TITLE
deps: update google-cloud-shared-config to 1.11.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.8.0</version>
+    <version>1.11.3</version>
   </parent>
 
   <properties>
@@ -30,22 +30,16 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.20.0</version>
+        <version>3.39.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>26.11.0</version>
+        <artifactId>google-cloud-bom</artifactId>
+        <version>0.231.0</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <!--TODO(dpcollins-google): remove this !-->
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>grpc-google-cloud-pubsublite-v1</artifactId>
-        <version>1.12.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -54,25 +48,20 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-pubsublite-v1</artifactId>
-      <!--TODO(dpcollins-google): remove explicit version !-->
-      <version>1.12.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsublite</artifactId>
-      <!--TODO(dpcollins-google): remove explicit version !-->
-      <version>1.12.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>pubsublite-kafka</artifactId>
-      <version>1.2.1</version>
+      <version>1.2.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
@@ -85,7 +74,7 @@
     <dependency>
       <groupId>com.google.flogger</groupId>
       <artifactId>google-extensions</artifactId>
-      <version>0.7.4</version>
+      <version>0.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/src/test/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTaskTest.java
+++ b/src/test/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTaskTest.java
@@ -336,6 +336,7 @@ public class CloudPubSubSinkTaskTest {
     partitionOffsets.put(new TopicPartition(KAFKA_TOPIC, 0), null);
     List<SinkRecord> records = getSampleRecords();
     ApiFuture<String> goodFuture = getSuccessfulPublishFuture();
+    when(goodFuture.isDone()).thenReturn(false);
     when(publisher.publish(any(PubsubMessage.class))).thenReturn(goodFuture);
     task.put(records);
     task.flush(partitionOffsets);
@@ -578,7 +579,9 @@ public class CloudPubSubSinkTaskTest {
     partitionOffsets.put(new TopicPartition(KAFKA_TOPIC, 0), null);
     List<SinkRecord> records = getSampleRecords();
     ApiFuture<String> badFuture = getFailedPublishFuture();
+    when(badFuture.isDone()).thenReturn(false);
     ApiFuture<String> goodFuture = getSuccessfulPublishFuture();
+    when(goodFuture.isDone()).thenReturn(false);
     when(publisher.publish(any(PubsubMessage.class)))
         .thenReturn(badFuture)
         .thenReturn(badFuture)


### PR DESCRIPTION
deps: update google-cloud-shared-dependencies to 3.39.0
deps: use google-cloud-bom 0.231.0 instead of libraries-bom
deps: depend on pubsublite libraries from google-cloud-bom
deps: update pubsublite-kafka to 1.2.2
deps: update flogger to 0.8
fix: An optimization in guava 33.3.0 broke our tests by not calling `addListener()` on futures which are already `isDone()`. Add mock call to make our futures not `isDone()` in some tests.
