### PR TITLE
fix: CloudPubSubSourceTask fails to ACK messages in Kafka 4.0 due to deprecated commitRecord method

### DIFF
--- a/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -42,6 +42,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -364,5 +366,10 @@ public class CloudPubSubSourceTask extends SourceTask {
         },
         MoreExecutors.directExecutor());
     log.trace("Committed {}", ackId);
+  }
+
+  @Override
+  public void commitRecord(SourceRecord record, RecordMetadata metadata) {
+    this.commitRecord(record);
   }
 }

--- a/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
+++ b/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceTask.java
@@ -42,7 +42,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-pubsub-group-kafka-connector/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #370 

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
