### PR TITLE
chore(deps): upgrade Google Cloud BOMs and Kafka Clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <kafka.version>3.9.0</kafka.version>
+    <kafka.version>3.9.1</kafka.version>
   </properties>
 
   <dependencyManagement>
@@ -30,14 +30,14 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.51.0</version>
+        <version>3.54.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bom</artifactId>
-        <version>0.231.0</version>
+        <version>0.253.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Updates core dependencies to their latest stable versions to ensure compatibility and pull in recent security patches.

Dependency Updates:
- Upgrade `google-cloud-shared-dependencies` to 3.54.1
- Upgrade `google-cloud-bom` to 0.253.0
- Upgrade `kafka-clients` and `connect-api` to 3.9.1
