### PR TITLE
chore: replace old partner teams with updated names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,11 +4,11 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/api-pubsub is the default owner for changes in this repo
-*                       @googleapis/cloud-sdk-java-team @googleapis/api-pubsub
+# The @googleapis/pubsub-team is the default owner for changes in this repo
+*                       @googleapis/cloud-sdk-java-team @googleapis/pubsub-team
 
 # for handwritten libraries, keep codeowner_team in .repo-metadata.json as owner
-**/*.java               @googleapis/api-pubsub
+**/*.java               @googleapis/pubsub-team
 
 
 # The java-samples-reviewers team is the default owner for samples changes

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -20,7 +20,7 @@ permissionRules:
     permission: admin
   - team: yoshi-java-admins
     permission: admin
-  - team: yoshi-java
+  - team: cloud-sdk-java-team
     permission: push
-  - team: api-pubsub
+  - team: pubsub-team
     permission: admin

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,7 +11,7 @@
   "repo": "googleapis/java-pubsub-group-kafka-connector",
   "repo_short": "java-pubsub-group-kafka-connector",
   "distribution_name": "com.google.cloud:pubsub-group-kafka-connector",
-  "codeowner_team": "@googleapis/api-pubsub",
+  "codeowner_team": "@googleapis/pubsub-team",
   "api_id": "pubsub.googleapis.com",
   "library_type": "AGENT",
   "transport": "grpc",


### PR DESCRIPTION
This PR replaces @googleapis/api-pubsub with @googleapis/pubsub-team and @googleapis/yoshi-java with @googleapis/cloud-sdk-java-team. b/478003109