### PR TITLE
fix: handle empty string message values in CloudPubSubSinkTask

### DIFF
--- a/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
+++ b/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkTask.java
@@ -176,7 +176,7 @@ public class CloudPubSubSinkTask extends SinkTask {
           attributes.put(header.key(), header.value().toString());
         }
       }
-      if (attributes.size() == 0 && value == null) {
+      if (attributes.isEmpty() && (value == null || value.isEmpty())) {
         log.warn("Message received with no value and no attributes. Not publishing message");
         SettableApiFuture<String> nullMessageFuture = SettableApiFuture.<String>create();
         nullMessageFuture.set("No message");


### PR DESCRIPTION
Treat empty string ("") payloads as equivalent to null when no attributes are present. Previously, only null values were checked, allowing empty messages to pass through and potentially stall processing.

Updated the condition to use attributes.isEmpty() and include value.isEmpty() alongside the null check to ensure invalid messages are consistently skipped.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-pubsub-group-kafka-connector/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
