### PR TITLE
feat: use self-signed JWTs for service accounts in ConnectorCredentialsProvider

### DIFF
--- a/src/main/java/com/google/pubsub/kafka/common/ConnectorCredentialsProvider.java
+++ b/src/main/java/com/google/pubsub/kafka/common/ConnectorCredentialsProvider.java
@@ -71,6 +71,7 @@ public class ConnectorCredentialsProvider implements CredentialsProvider {
     return new ConnectorCredentialsProvider(
         () ->
             ServiceAccountCredentials.fromStream(new FileInputStream(credentialsSAPath))
+                .createWithUseJwtAccessWithScope(true)
                 .createScoped(GCP_SCOPE));
   }
 
@@ -79,6 +80,7 @@ public class ConnectorCredentialsProvider implements CredentialsProvider {
         () ->
             ServiceAccountCredentials.fromStream(
                     new ByteArrayInputStream(credentialsSAJson.getBytes()))
+                .createWithUseJwtAccessWithScope(true)
                 .createScoped(GCP_SCOPE));
   }
 


### PR DESCRIPTION
See https://google.aip.dev/auth/4111 - this should improve efficiency/reliability by avoiding OAuth token exchange