### PR TITLE
feat: conditionally validate official Cloud Pub/Sub endpoints

### DIFF
--- a/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
+++ b/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
@@ -120,7 +120,7 @@ public final class ConnectorUtils {
   }
 
   /** Validator class for {@link ConnectorUtils#CPS_ENDPOINT}. */
-  public static class CpsEndpointValidator implements ConfigDef.Validator {
+  public static final class CpsEndpointValidator implements ConfigDef.Validator {
     private final Supplier<String> envLookup;
 
     public CpsEndpointValidator() {
@@ -154,13 +154,13 @@ public final class ConnectorUtils {
   }
 
   // A shared executor for Pub/Sub clients to use.
-  private static Optional<ScheduledExecutorService> SYSTEM_EXECUTOR = Optional.empty();
+  private static Optional<ScheduledExecutorService> systemExecutor = Optional.empty();
 
   public static synchronized ScheduledExecutorService getSystemExecutor() {
-    if (!SYSTEM_EXECUTOR.isPresent()) {
-      SYSTEM_EXECUTOR = Optional.of(newDaemonExecutor("pubsub-connect-system"));
+    if (!systemExecutor.isPresent()) {
+      systemExecutor = Optional.of(newDaemonExecutor("pubsub-connect-system"));
     }
-    return SYSTEM_EXECUTOR.get();
+    return systemExecutor.get();
   }
 
   // Resolve the endpoint. When using the emulator, prefer PUBSUB_EMULATOR_HOST and fall back to

--- a/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
+++ b/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
@@ -18,6 +18,7 @@ package com.google.pubsub.kafka.common;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.ByteString;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -28,6 +29,8 @@ import org.apache.kafka.common.config.ConfigException;
 
 /** Utility methods and constants that are repeated across one or more classes. */
 public class ConnectorUtils {
+  private ConnectorUtils() {}
+
   public static final String SCHEMA_NAME = ByteString.class.getName();
   public static final String CPS_SUBSCRIPTION_FORMAT = "projects/%s/subscriptions/%s";
   public static final String CPS_PROJECT_CONFIG = "cps.project";
@@ -135,16 +138,11 @@ public class ConnectorUtils {
     @Override
     public void ensureValid(String name, Object o) {
       String enforceOfficialEndpoints = envLookup.get();
-      if (!Boolean.parseBoolean(enforceOfficialEndpoints) && !"1".equals(enforceOfficialEndpoints)) {
+      if (!Boolean.parseBoolean(enforceOfficialEndpoints)
+          && !Objects.equals(enforceOfficialEndpoints, "1")) {
         return;
       }
-      if (o == null) {
-        validateEndpoint(null);
-      } else if (o instanceof String) {
-        validateEndpoint((String) o);
-      } else {
-        validateEndpoint(o.toString());
-      }
+      validateEndpoint(o == null ? null : o.toString());
     }
 
     @Override

--- a/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
+++ b/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
@@ -53,19 +53,18 @@ public final class ConnectorUtils {
   public static final String KAFKA_TIMESTAMP_ATTRIBUTE = "kafka.timestamp";
 
   /**
-   * Patterns matching Google Cloud Pub/Sub endpoints:
-   * 1. Global: pubsub.googleapis.com
-   * 2. Locational: <region>-pubsub.googleapis.com (e.g. us-central1-pubsub.googleapis.com)
-   * 3. Regional: pubsub.<region>.rep.googleapis.com (e.g. pubsub.us-central1.rep.googleapis.com)
+   * Patterns matching Google Cloud Pub/Sub endpoints: 1. Global: pubsub.googleapis.com 2.
+   * Locational: <region>-pubsub.googleapis.com (e.g. us-central1-pubsub.googleapis.com) 3.
+   * Regional: pubsub.<region>.rep.googleapis.com (e.g. pubsub.us-central1.rep.googleapis.com)
    */
   public static final Pattern GLOBAL_ENDPOINT_PATTERN =
-    Pattern.compile("^pubsub\\.googleapis\\.com$");
+      Pattern.compile("^pubsub\\.googleapis\\.com$");
 
   public static final Pattern LOCATIONAL_ENDPOINT_PATTERN =
-    Pattern.compile("^[a-z]+-[a-z]+[0-9]+-pubsub\\.googleapis\\.com$");
+      Pattern.compile("^[a-z]+-[a-z]+[0-9]+-pubsub\\.googleapis\\.com$");
 
   public static final Pattern REGIONAL_REP_ENDPOINT_PATTERN =
-    Pattern.compile("^pubsub\\.[a-z]+-[a-z]+[0-9]+\\.rep\\.googleapis\\.com$");
+      Pattern.compile("^pubsub\\.[a-z]+-[a-z]+[0-9]+\\.rep\\.googleapis\\.com$");
 
   public static boolean isAllowedCpsHost(String host) {
     if (host == null) {
@@ -103,9 +102,7 @@ public final class ConnectorUtils {
 
     if (!isAllowedCpsHost(host)) {
       throw new ConfigException(
-          CPS_ENDPOINT,
-          endpoint,
-          "Host is not an allowed Cloud Pub/Sub endpoint.");
+          CPS_ENDPOINT, endpoint, "Host is not an allowed Cloud Pub/Sub endpoint.");
     }
 
     int port;
@@ -143,7 +140,8 @@ public final class ConnectorUtils {
 
     @Override
     public String toString() {
-      return "Official Cloud Pub/Sub endpoint in '<host>:<port>' format (e.g., 'pubsub.googleapis.com:443')";
+      return "Official Cloud Pub/Sub endpoint in '<host>:<port>' format (e.g.,"
+          + " 'pubsub.googleapis.com:443')";
     }
   }
 

--- a/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
+++ b/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
@@ -28,7 +28,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 /** Utility methods and constants that are repeated across one or more classes. */
-public class ConnectorUtils {
+public final class ConnectorUtils {
   private ConnectorUtils() {}
 
   public static final String SCHEMA_NAME = ByteString.class.getName();
@@ -124,11 +124,7 @@ public class ConnectorUtils {
     private final Supplier<String> envLookup;
 
     public CpsEndpointValidator() {
-      this(
-          () -> {
-            String prop = System.getProperty(CPS_ENFORCE_OFFICIAL_ENDPOINTS);
-            return prop != null ? prop : System.getenv(CPS_ENFORCE_OFFICIAL_ENDPOINTS);
-          });
+      this(() -> System.getenv(CPS_ENFORCE_OFFICIAL_ENDPOINTS));
     }
 
     CpsEndpointValidator(Supplier<String> envLookup) {

--- a/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
+++ b/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
@@ -20,6 +20,9 @@ import com.google.protobuf.ByteString;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.regex.Pattern;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
 
 /** Utility methods and constants that are repeated across one or more classes. */
 public class ConnectorUtils {
@@ -31,6 +34,7 @@ public class ConnectorUtils {
   public static final String CPS_DEFAULT_ENDPOINT = "pubsub.googleapis.com:443";
   public static final String CPS_USE_EMULATOR = "cps.useEmulator";
   public static final String PUBSUB_EMULATOR_HOST = "PUBSUB_EMULATOR_HOST";
+  public static final String CPS_ENFORCE_OFFICIAL_ENDPOINTS = "CPS_ENFORCE_OFFICIAL_ENDPOINTS";
   public static final String CPS_MESSAGE_KEY_ATTRIBUTE = "key";
   public static final String CPS_ORDERING_KEY_ATTRIBUTE = "orderingKey";
   public static final String GCP_CREDENTIALS_FILE_PATH_CONFIG = "gcp.credentials.file.path";
@@ -42,6 +46,91 @@ public class ConnectorUtils {
   public static final String KAFKA_PARTITION_ATTRIBUTE = "kafka.partition";
   public static final String KAFKA_OFFSET_ATTRIBUTE = "kafka.offset";
   public static final String KAFKA_TIMESTAMP_ATTRIBUTE = "kafka.timestamp";
+
+  /**
+   * Patterns matching Google Cloud Pub/Sub endpoints:
+   * 1. Global: pubsub.googleapis.com
+   * 2. Locational: <region>-pubsub.googleapis.com (e.g. us-central1-pubsub.googleapis.com)
+   * 3. Regional: pubsub.<region>.rep.googleapis.com (e.g. pubsub.us-central1.rep.googleapis.com)
+   */
+  public static final Pattern GLOBAL_ENDPOINT_PATTERN =
+    Pattern.compile("^pubsub\\.googleapis\\.com$");
+
+  public static final Pattern LOCATIONAL_ENDPOINT_PATTERN =
+    Pattern.compile("^[a-z]+-[a-z]+[0-9]+-pubsub\\.googleapis\\.com$");
+
+  public static final Pattern REGIONAL_REP_ENDPOINT_PATTERN =
+    Pattern.compile("^pubsub\\.[a-z]+-[a-z]+[0-9]+\\.rep\\.googleapis\\.com$");
+
+  public static boolean isAllowedCpsHost(String host) {
+    return GLOBAL_ENDPOINT_PATTERN.matcher(host).matches()
+      || LOCATIONAL_ENDPOINT_PATTERN.matcher(host).matches()
+      || REGIONAL_REP_ENDPOINT_PATTERN.matcher(host).matches();
+  }
+
+  public static void validateEndpoint(String endpoint) {
+    if (endpoint == null || endpoint.trim().isEmpty()) {
+      throw new ConfigException(CPS_ENDPOINT, endpoint, "Endpoint cannot be null or empty.");
+    }
+    String trimmed = endpoint.trim();
+
+    int colonIndex = trimmed.lastIndexOf(':');
+    if (colonIndex <= 0
+        || colonIndex != trimmed.indexOf(':')
+        || colonIndex == trimmed.length() - 1
+        || trimmed.contains("/")
+        || trimmed.contains("?")
+        || trimmed.contains("#")
+        || trimmed.contains("@")) {
+      throw new ConfigException(
+          CPS_ENDPOINT,
+          endpoint,
+          "Endpoint must be in '<host>:<port>' format (e.g., 'pubsub.googleapis.com:443').");
+    }
+
+    String host = trimmed.substring(0, colonIndex);
+    String portStr = trimmed.substring(colonIndex + 1);
+
+    if (!isAllowedCpsHost(host)) {
+      throw new ConfigException(
+          CPS_ENDPOINT,
+          endpoint,
+          "Host is not an allowed Cloud Pub/Sub endpoint.");
+    }
+
+    int port;
+    try {
+      port = Integer.parseInt(portStr);
+    } catch (NumberFormatException unused) {
+      port = -1;
+    }
+    if (port < 1 || port > 65535) {
+      throw new ConfigException(CPS_ENDPOINT, endpoint, "Port must be between 1 and 65535.");
+    }
+  }
+
+  /** Validator class for {@link ConnectorUtils#CPS_ENDPOINT}. */
+  public static class CpsEndpointValidator implements ConfigDef.Validator {
+    @Override
+    public void ensureValid(String name, Object o) {
+      String enforceOfficialEndpoints = System.getenv(CPS_ENFORCE_OFFICIAL_ENDPOINTS);
+      if (!Boolean.parseBoolean(enforceOfficialEndpoints) && !"1".equals(enforceOfficialEndpoints)) {
+        return;
+      }
+      if (o == null) {
+        validateEndpoint(null);
+      } else if (o instanceof String) {
+        validateEndpoint((String) o);
+      } else {
+        validateEndpoint(o.toString());
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "Official Cloud Pub/Sub endpoint in '<host>:<port>' format (e.g., 'pubsub.googleapis.com:443')";
+    }
+  }
 
   private static ScheduledExecutorService newDaemonExecutor(String prefix) {
     return Executors.newScheduledThreadPool(

--- a/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
+++ b/src/main/java/com/google/pubsub/kafka/common/ConnectorUtils.java
@@ -17,9 +17,11 @@ package com.google.pubsub.kafka.common;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.ByteString;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
@@ -63,9 +65,13 @@ public class ConnectorUtils {
     Pattern.compile("^pubsub\\.[a-z]+-[a-z]+[0-9]+\\.rep\\.googleapis\\.com$");
 
   public static boolean isAllowedCpsHost(String host) {
-    return GLOBAL_ENDPOINT_PATTERN.matcher(host).matches()
-      || LOCATIONAL_ENDPOINT_PATTERN.matcher(host).matches()
-      || REGIONAL_REP_ENDPOINT_PATTERN.matcher(host).matches();
+    if (host == null) {
+      return false;
+    }
+    String normalizedHost = host.toLowerCase(Locale.ROOT);
+    return GLOBAL_ENDPOINT_PATTERN.matcher(normalizedHost).matches()
+        || LOCATIONAL_ENDPOINT_PATTERN.matcher(normalizedHost).matches()
+        || REGIONAL_REP_ENDPOINT_PATTERN.matcher(normalizedHost).matches();
   }
 
   public static void validateEndpoint(String endpoint) {
@@ -79,6 +85,7 @@ public class ConnectorUtils {
         || colonIndex != trimmed.indexOf(':')
         || colonIndex == trimmed.length() - 1
         || trimmed.contains("/")
+        || trimmed.contains("\\")
         || trimmed.contains("?")
         || trimmed.contains("#")
         || trimmed.contains("@")) {
@@ -111,9 +118,23 @@ public class ConnectorUtils {
 
   /** Validator class for {@link ConnectorUtils#CPS_ENDPOINT}. */
   public static class CpsEndpointValidator implements ConfigDef.Validator {
+    private final Supplier<String> envLookup;
+
+    public CpsEndpointValidator() {
+      this(
+          () -> {
+            String prop = System.getProperty(CPS_ENFORCE_OFFICIAL_ENDPOINTS);
+            return prop != null ? prop : System.getenv(CPS_ENFORCE_OFFICIAL_ENDPOINTS);
+          });
+    }
+
+    CpsEndpointValidator(Supplier<String> envLookup) {
+      this.envLookup = envLookup;
+    }
+
     @Override
     public void ensureValid(String name, Object o) {
-      String enforceOfficialEndpoints = System.getenv(CPS_ENFORCE_OFFICIAL_ENDPOINTS);
+      String enforceOfficialEndpoints = envLookup.get();
       if (!Boolean.parseBoolean(enforceOfficialEndpoints) && !"1".equals(enforceOfficialEndpoints)) {
         return;
       }

--- a/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
+++ b/src/main/java/com/google/pubsub/kafka/sink/CloudPubSubSinkConnector.java
@@ -286,6 +286,7 @@ public class CloudPubSubSinkConnector extends SinkConnector {
             ConnectorUtils.CPS_ENDPOINT,
             Type.STRING,
             ConnectorUtils.CPS_DEFAULT_ENDPOINT,
+            new ConnectorUtils.CpsEndpointValidator(),
             Importance.LOW,
             "The Pub/Sub endpoint to use.")
         .define(

--- a/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
+++ b/src/main/java/com/google/pubsub/kafka/source/CloudPubSubSourceConnector.java
@@ -301,6 +301,7 @@ public class CloudPubSubSourceConnector extends SourceConnector {
             ConnectorUtils.CPS_ENDPOINT,
             Type.STRING,
             ConnectorUtils.CPS_DEFAULT_ENDPOINT,
+            new ConnectorUtils.CpsEndpointValidator(),
             Importance.LOW,
             "The Pub/Sub endpoint to use.")
         .define(

--- a/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
+++ b/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
@@ -28,7 +28,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ConnectorUtilsTest {
 
-
   @Test
   public void testValidDefaultEndpoint() {
     ConnectorUtils.validateEndpoint(ConnectorUtils.CPS_DEFAULT_ENDPOINT);
@@ -140,7 +139,8 @@ public class ConnectorUtilsTest {
     assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("attacker.com:443"));
     assertThrows(
         ConfigException.class, () -> ConnectorUtils.validateEndpoint("pubsub.attacker.com:443"));
-    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("googleapis.com:443"));
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("googleapis.com:443"));
     assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("google.com:443"));
     assertThrows(
         ConfigException.class, () -> ConnectorUtils.validateEndpoint("storage.googleapis.com:443"));
@@ -224,8 +224,7 @@ public class ConnectorUtilsTest {
   @Test
   public void testInvalidEndpoints_pathsQueryFragment() {
     assertThrows(
-        ConfigException.class,
-        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443/"));
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443/"));
     assertThrows(
         ConfigException.class,
         () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443\\"));
@@ -295,8 +294,7 @@ public class ConnectorUtilsTest {
     assertThrows(
         ConfigException.class,
         () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443:443"));
-    assertThrows(
-        ConfigException.class, () -> ConnectorUtils.validateEndpoint(":443"));
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint(":443"));
   }
 
   @Test
@@ -342,8 +340,7 @@ public class ConnectorUtilsTest {
     // Official endpoints pass
     validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "pubsub.googleapis.com:443");
     validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "us-central1-pubsub.googleapis.com:443");
-    validator.ensureValid(
-        ConnectorUtils.CPS_ENDPOINT, "pubsub.us-central1.rep.googleapis.com:443");
+    validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "pubsub.us-central1.rep.googleapis.com:443");
     validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "PUBSUB.GOOGLEAPIS.COM:443");
 
     // Unofficial or invalid endpoints fail
@@ -360,11 +357,9 @@ public class ConnectorUtilsTest {
         ConfigException.class,
         () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "pubsub.googleapis.com"));
     assertThrows(
-        ConfigException.class,
-        () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, null));
+        ConfigException.class, () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, null));
     assertThrows(
-        ConfigException.class,
-        () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, ""));
+        ConfigException.class, () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, ""));
   }
 
   @Test
@@ -383,8 +378,7 @@ public class ConnectorUtilsTest {
 
   @Test
   public void testCpsEndpointValidator_defaultConstructor() {
-    ConnectorUtils.CpsEndpointValidator validator =
-        new ConnectorUtils.CpsEndpointValidator();
+    ConnectorUtils.CpsEndpointValidator validator = new ConnectorUtils.CpsEndpointValidator();
     // Official endpoint always passes
     validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "pubsub.googleapis.com:443");
 
@@ -407,16 +401,15 @@ public class ConnectorUtilsTest {
       if (envEnabled) {
         // Setting system property to false must be ignored; env var still enforces endpoints.
         System.setProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS, "false");
-        ConnectorUtils.CpsEndpointValidator validator =
-            new ConnectorUtils.CpsEndpointValidator();
+        ConnectorUtils.CpsEndpointValidator validator = new ConnectorUtils.CpsEndpointValidator();
         assertThrows(
             ConfigException.class,
             () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085"));
       } else {
-        // Setting system property to true must be ignored; env var is disabled so unofficial passes.
+        // Setting system property to true must be ignored; env var is disabled so unofficial
+        // passes.
         System.setProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS, "true");
-        ConnectorUtils.CpsEndpointValidator validator =
-            new ConnectorUtils.CpsEndpointValidator();
+        ConnectorUtils.CpsEndpointValidator validator = new ConnectorUtils.CpsEndpointValidator();
         validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085");
       }
     } finally {
@@ -463,8 +456,7 @@ public class ConnectorUtilsTest {
             "Endpoint must be in '<host>:<port>' format (e.g., 'pubsub.googleapis.com:443').");
 
     ConfigException hostEx =
-        assertThrows(
-            ConfigException.class, () -> ConnectorUtils.validateEndpoint("evil.com:443"));
+        assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("evil.com:443"));
     assertThat(hostEx)
         .hasMessageThat()
         .endsWith(": Host is not an allowed Cloud Pub/Sub endpoint.");
@@ -472,7 +464,8 @@ public class ConnectorUtilsTest {
 
     ConfigException portEx =
         assertThrows(
-            ConfigException.class, () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:0"));
+            ConfigException.class,
+            () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:0"));
     assertThat(portEx).hasMessageThat().contains("Port must be between 1 and 65535.");
 
     ConfigException portNotNumberEx =

--- a/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
+++ b/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
+import java.util.Objects;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -388,7 +389,7 @@ public class ConnectorUtilsTest {
     validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "pubsub.googleapis.com:443");
 
     String env = System.getenv(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS);
-    if (!Boolean.parseBoolean(env) && !"1".equals(env)) {
+    if (!Boolean.parseBoolean(env) && !Objects.equals(env, "1")) {
       validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085");
     } else {
       assertThrows(
@@ -402,7 +403,7 @@ public class ConnectorUtilsTest {
     String originalProp = System.getProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS);
     try {
       String env = System.getenv(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS);
-      boolean envEnabled = Boolean.parseBoolean(env) || "1".equals(env);
+      boolean envEnabled = Boolean.parseBoolean(env) || Objects.equals(env, "1");
       if (envEnabled) {
         // Setting system property to false must be ignored; env var still enforces endpoints.
         System.setProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS, "false");

--- a/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
+++ b/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
@@ -408,22 +408,24 @@ public class ConnectorUtilsTest {
   public void testErrorMessages() {
     ConfigException nullEx =
         assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint(null));
-    assertThat(nullEx.getMessage()).contains("Endpoint cannot be null or empty.");
+    assertThat(nullEx).hasMessageThat().contains("Endpoint cannot be null or empty.");
 
     ConfigException emptyEx =
         assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint(""));
-    assertThat(emptyEx.getMessage()).contains("Endpoint cannot be null or empty.");
+    assertThat(emptyEx).hasMessageThat().contains("Endpoint cannot be null or empty.");
 
     ConfigException noPortEx =
         assertThrows(
             ConfigException.class, () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com"));
-    assertThat(noPortEx.getMessage())
+    assertThat(noPortEx)
+        .hasMessageThat()
         .contains(
             "Endpoint must be in '<host>:<port>' format (e.g., 'pubsub.googleapis.com:443').");
 
     ConfigException colonPrefixEx =
         assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint(":443"));
-    assertThat(colonPrefixEx.getMessage())
+    assertThat(colonPrefixEx)
+        .hasMessageThat()
         .contains(
             "Endpoint must be in '<host>:<port>' format (e.g., 'pubsub.googleapis.com:443').");
 
@@ -431,26 +433,28 @@ public class ConnectorUtilsTest {
         assertThrows(
             ConfigException.class,
             () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com\\evil:443"));
-    assertThat(backslashEx.getMessage())
+    assertThat(backslashEx)
+        .hasMessageThat()
         .contains(
             "Endpoint must be in '<host>:<port>' format (e.g., 'pubsub.googleapis.com:443').");
 
     ConfigException hostEx =
         assertThrows(
             ConfigException.class, () -> ConnectorUtils.validateEndpoint("evil.com:443"));
-    assertThat(hostEx.getMessage())
+    assertThat(hostEx)
+        .hasMessageThat()
         .endsWith(": Host is not an allowed Cloud Pub/Sub endpoint.");
-    assertThat(hostEx.getMessage()).doesNotContain("Host 'evil.com'");
+    assertThat(hostEx).hasMessageThat().doesNotContain("Host 'evil.com'");
 
     ConfigException portEx =
         assertThrows(
             ConfigException.class, () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:0"));
-    assertThat(portEx.getMessage()).contains("Port must be between 1 and 65535.");
+    assertThat(portEx).hasMessageThat().contains("Port must be between 1 and 65535.");
 
     ConfigException portNotNumberEx =
         assertThrows(
             ConfigException.class,
             () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:invalid"));
-    assertThat(portNotNumberEx.getMessage()).contains("Port must be between 1 and 65535.");
+    assertThat(portNotNumberEx).hasMessageThat().contains("Port must be between 1 and 65535.");
   }
 }

--- a/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
+++ b/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
@@ -17,6 +17,7 @@ package com.google.pubsub.kafka.common;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
+import java.util.Arrays;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,16 +38,18 @@ public class ConnectorUtilsTest {
     assertThat(ConnectorUtils.isAllowedCpsHost("asia-east1-pubsub.googleapis.com")).isTrue();
     assertThat(ConnectorUtils.isAllowedCpsHost("pubsub.asia-east1.rep.googleapis.com")).isTrue();
 
-    // Uppercase / mixed case rejected
-    assertThat(ConnectorUtils.isAllowedCpsHost("PUBSUB.GOOGLEAPIS.COM")).isFalse();
-    assertThat(ConnectorUtils.isAllowedCpsHost("PubSub.GoogleApis.Com")).isFalse();
-    assertThat(ConnectorUtils.isAllowedCpsHost("ASIA-EAST1-PUBSUB.GOOGLEAPIS.COM")).isFalse();
-    assertThat(ConnectorUtils.isAllowedCpsHost("pubsub.asia-east1.REP.googleapis.com")).isFalse();
+    // Uppercase / mixed case allowed (case-insensitive)
+    assertThat(ConnectorUtils.isAllowedCpsHost("PUBSUB.GOOGLEAPIS.COM")).isTrue();
+    assertThat(ConnectorUtils.isAllowedCpsHost("PubSub.GoogleApis.Com")).isTrue();
+    assertThat(ConnectorUtils.isAllowedCpsHost("ASIA-EAST1-PUBSUB.GOOGLEAPIS.COM")).isTrue();
+    assertThat(ConnectorUtils.isAllowedCpsHost("pubsub.asia-east1.REP.googleapis.com")).isTrue();
 
     // Hosts with ports or paths rejected by host matcher
     assertThat(ConnectorUtils.isAllowedCpsHost("pubsub.googleapis.com:443")).isFalse();
+    assertThat(ConnectorUtils.isAllowedCpsHost("pubsub.googleapis.com\\foo")).isFalse();
     assertThat(ConnectorUtils.isAllowedCpsHost("evil.com")).isFalse();
     assertThat(ConnectorUtils.isAllowedCpsHost("169.254.169.254")).isFalse();
+    assertThat(ConnectorUtils.isAllowedCpsHost(null)).isFalse();
   }
 
   @Test
@@ -81,25 +84,13 @@ public class ConnectorUtilsTest {
   }
 
   @Test
-  public void testInvalidEndpoints_uppercaseAndMixedCase() {
-    assertThrows(
-        ConfigException.class,
-        () -> ConnectorUtils.validateEndpoint("PUBSUB.GOOGLEAPIS.COM:443"));
-    assertThrows(
-        ConfigException.class,
-        () -> ConnectorUtils.validateEndpoint("PubSub.GoogleApis.Com:443"));
-    assertThrows(
-        ConfigException.class,
-        () -> ConnectorUtils.validateEndpoint("ASIA-EAST1-PUBSUB.GOOGLEAPIS.COM:443"));
-    assertThrows(
-        ConfigException.class,
-        () -> ConnectorUtils.validateEndpoint("Asia-East1-Pubsub.Googleapis.com:443"));
-    assertThrows(
-        ConfigException.class,
-        () -> ConnectorUtils.validateEndpoint("PUBSUB.ASIA-EAST1.REP.GOOGLEAPIS.COM:443"));
-    assertThrows(
-        ConfigException.class,
-        () -> ConnectorUtils.validateEndpoint("pubsub.Asia-East1.rep.googleapis.com:443"));
+  public void testValidEndpoints_caseInsensitive() {
+    ConnectorUtils.validateEndpoint("PUBSUB.GOOGLEAPIS.COM:443");
+    ConnectorUtils.validateEndpoint("PubSub.GoogleApis.Com:443");
+    ConnectorUtils.validateEndpoint("ASIA-EAST1-PUBSUB.GOOGLEAPIS.COM:443");
+    ConnectorUtils.validateEndpoint("Asia-East1-Pubsub.Googleapis.com:443");
+    ConnectorUtils.validateEndpoint("PUBSUB.ASIA-EAST1.REP.GOOGLEAPIS.COM:443");
+    ConnectorUtils.validateEndpoint("pubsub.Asia-East1.rep.googleapis.com:443");
   }
 
   @Test
@@ -160,6 +151,9 @@ public class ConnectorUtilsTest {
     assertThrows(
         ConfigException.class,
         () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com.evil.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("PUBSUB.GOOGLEAPIS.COM.EVIL.COM:443"));
     assertThrows(
         ConfigException.class,
         () -> ConnectorUtils.validateEndpoint("asia-east1-pubsub.googleapis.com.attacker.com:443"));
@@ -232,10 +226,22 @@ public class ConnectorUtilsTest {
         () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443/"));
     assertThrows(
         ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443\\"));
+    assertThrows(
+        ConfigException.class,
         () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443/v1/projects"));
     assertThrows(
         ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443\\v1\\projects"));
+    assertThrows(
+        ConfigException.class,
         () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443/foo"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443\\foo"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com\\foo:443"));
     assertThrows(
         ConfigException.class,
         () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443?query=1"));
@@ -261,6 +267,9 @@ public class ConnectorUtilsTest {
     assertThrows(
         ConfigException.class,
         () -> ConnectorUtils.validateEndpoint("//pubsub.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("\\\\pubsub.googleapis.com:443"));
     assertThrows(
         ConfigException.class,
         () -> ConnectorUtils.validateEndpoint("ftp://pubsub.googleapis.com:443"));
@@ -298,6 +307,104 @@ public class ConnectorUtilsTest {
   }
 
   @Test
+  public void testCpsEndpointValidator_disabledWhenUnset() {
+    ConnectorUtils.CpsEndpointValidator validator =
+        new ConnectorUtils.CpsEndpointValidator(() -> null);
+
+    // Any endpoint is allowed when enforcement is unset / disabled
+    validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "pubsub.googleapis.com:443");
+    validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085");
+    validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "evil.com:443");
+    validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "169.254.169.254:80");
+    validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "not-an-endpoint");
+    validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, null);
+  }
+
+  @Test
+  public void testCpsEndpointValidator_disabledWhenFalseOrOtherValues() {
+    for (String disabledVal : Arrays.asList("false", "FALSE", "0", "random", "")) {
+      ConnectorUtils.CpsEndpointValidator validator =
+          new ConnectorUtils.CpsEndpointValidator(() -> disabledVal);
+
+      validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085");
+      validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "evil.com:443");
+      validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, null);
+    }
+  }
+
+  @Test
+  public void testCpsEndpointValidator_enabledWithTrue() {
+    ConnectorUtils.CpsEndpointValidator validator =
+        new ConnectorUtils.CpsEndpointValidator(() -> "true");
+
+    // Official endpoints pass
+    validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "pubsub.googleapis.com:443");
+    validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "us-central1-pubsub.googleapis.com:443");
+    validator.ensureValid(
+        ConnectorUtils.CPS_ENDPOINT, "pubsub.us-central1.rep.googleapis.com:443");
+    validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "PUBSUB.GOOGLEAPIS.COM:443");
+
+    // Unofficial or invalid endpoints fail
+    assertThrows(
+        ConfigException.class,
+        () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085"));
+    assertThrows(
+        ConfigException.class,
+        () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "evil.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "169.254.169.254:80"));
+    assertThrows(
+        ConfigException.class,
+        () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "pubsub.googleapis.com"));
+    assertThrows(
+        ConfigException.class,
+        () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, null));
+    assertThrows(
+        ConfigException.class,
+        () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, ""));
+  }
+
+  @Test
+  public void testCpsEndpointValidator_enabledWithOne() {
+    ConnectorUtils.CpsEndpointValidator validator =
+        new ConnectorUtils.CpsEndpointValidator(() -> "1");
+
+    validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "pubsub.googleapis.com:443");
+    assertThrows(
+        ConfigException.class,
+        () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085"));
+    assertThrows(
+        ConfigException.class,
+        () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "evil.com:443"));
+  }
+
+  @Test
+  public void testCpsEndpointValidator_defaultConstructorWithSystemProperty() {
+    String originalProp = System.getProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS);
+    try {
+      System.setProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS, "false");
+      ConnectorUtils.CpsEndpointValidator disabledValidator =
+          new ConnectorUtils.CpsEndpointValidator();
+      disabledValidator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085");
+
+      System.setProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS, "true");
+      ConnectorUtils.CpsEndpointValidator enabledValidator =
+          new ConnectorUtils.CpsEndpointValidator();
+      enabledValidator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "pubsub.googleapis.com:443");
+      assertThrows(
+          ConfigException.class,
+          () -> enabledValidator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085"));
+    } finally {
+      if (originalProp != null) {
+        System.setProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS, originalProp);
+      } else {
+        System.clearProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS);
+      }
+    }
+  }
+
+  @Test
   public void testErrorMessages() {
     ConfigException nullEx =
         assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint(null));
@@ -317,6 +424,14 @@ public class ConnectorUtilsTest {
     ConfigException colonPrefixEx =
         assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint(":443"));
     assertThat(colonPrefixEx.getMessage())
+        .contains(
+            "Endpoint must be in '<host>:<port>' format (e.g., 'pubsub.googleapis.com:443').");
+
+    ConfigException backslashEx =
+        assertThrows(
+            ConfigException.class,
+            () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com\\evil:443"));
+    assertThat(backslashEx.getMessage())
         .contains(
             "Endpoint must be in '<host>:<port>' format (e.g., 'pubsub.googleapis.com:443').");
 

--- a/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
+++ b/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
@@ -381,21 +381,43 @@ public class ConnectorUtilsTest {
   }
 
   @Test
-  public void testCpsEndpointValidator_defaultConstructorWithSystemProperty() {
-    String originalProp = System.getProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS);
-    try {
-      System.setProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS, "false");
-      ConnectorUtils.CpsEndpointValidator disabledValidator =
-          new ConnectorUtils.CpsEndpointValidator();
-      disabledValidator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085");
+  public void testCpsEndpointValidator_defaultConstructor() {
+    ConnectorUtils.CpsEndpointValidator validator =
+        new ConnectorUtils.CpsEndpointValidator();
+    // Official endpoint always passes
+    validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "pubsub.googleapis.com:443");
 
-      System.setProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS, "true");
-      ConnectorUtils.CpsEndpointValidator enabledValidator =
-          new ConnectorUtils.CpsEndpointValidator();
-      enabledValidator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "pubsub.googleapis.com:443");
+    String env = System.getenv(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS);
+    if (!Boolean.parseBoolean(env) && !"1".equals(env)) {
+      validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085");
+    } else {
       assertThrows(
           ConfigException.class,
-          () -> enabledValidator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085"));
+          () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085"));
+    }
+  }
+
+  @Test
+  public void testCpsEndpointValidator_ignoresSystemProperty() {
+    String originalProp = System.getProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS);
+    try {
+      String env = System.getenv(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS);
+      boolean envEnabled = Boolean.parseBoolean(env) || "1".equals(env);
+      if (envEnabled) {
+        // Setting system property to false must be ignored; env var still enforces endpoints.
+        System.setProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS, "false");
+        ConnectorUtils.CpsEndpointValidator validator =
+            new ConnectorUtils.CpsEndpointValidator();
+        assertThrows(
+            ConfigException.class,
+            () -> validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085"));
+      } else {
+        // Setting system property to true must be ignored; env var is disabled so unofficial passes.
+        System.setProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS, "true");
+        ConnectorUtils.CpsEndpointValidator validator =
+            new ConnectorUtils.CpsEndpointValidator();
+        validator.ensureValid(ConnectorUtils.CPS_ENDPOINT, "localhost:8085");
+      }
     } finally {
       if (originalProp != null) {
         System.setProperty(ConnectorUtils.CPS_ENFORCE_OFFICIAL_ENDPOINTS, originalProp);

--- a/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
+++ b/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.pubsub.kafka.common;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ConnectorUtilsTest {
+
+
+  @Test
+  public void testValidDefaultEndpoint() {
+    ConnectorUtils.validateEndpoint(ConnectorUtils.CPS_DEFAULT_ENDPOINT);
+  }
+
+  @Test
+  public void testIsAllowedCpsHost() {
+    assertThat(ConnectorUtils.isAllowedCpsHost("pubsub.googleapis.com")).isTrue();
+    assertThat(ConnectorUtils.isAllowedCpsHost("asia-east1-pubsub.googleapis.com")).isTrue();
+    assertThat(ConnectorUtils.isAllowedCpsHost("pubsub.asia-east1.rep.googleapis.com")).isTrue();
+
+    // Uppercase / mixed case rejected
+    assertThat(ConnectorUtils.isAllowedCpsHost("PUBSUB.GOOGLEAPIS.COM")).isFalse();
+    assertThat(ConnectorUtils.isAllowedCpsHost("PubSub.GoogleApis.Com")).isFalse();
+    assertThat(ConnectorUtils.isAllowedCpsHost("ASIA-EAST1-PUBSUB.GOOGLEAPIS.COM")).isFalse();
+    assertThat(ConnectorUtils.isAllowedCpsHost("pubsub.asia-east1.REP.googleapis.com")).isFalse();
+
+    // Hosts with ports or paths rejected by host matcher
+    assertThat(ConnectorUtils.isAllowedCpsHost("pubsub.googleapis.com:443")).isFalse();
+    assertThat(ConnectorUtils.isAllowedCpsHost("evil.com")).isFalse();
+    assertThat(ConnectorUtils.isAllowedCpsHost("169.254.169.254")).isFalse();
+  }
+
+  @Test
+  public void testValidGlobalEndpoints() {
+    ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("pubsub.googleapis.com:80");
+    ConnectorUtils.validateEndpoint("  pubsub.googleapis.com:443  ");
+  }
+
+  @Test
+  public void testValidLocationalEndpoints() {
+    ConnectorUtils.validateEndpoint("asia-east1-pubsub.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("us-central1-pubsub.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("europe-west1-pubsub.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("northamerica-northeast1-pubsub.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("southamerica-east1-pubsub.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("australia-southeast1-pubsub.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("me-central1-pubsub.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("africa-south1-pubsub.googleapis.com:443");
+  }
+
+  @Test
+  public void testValidRegionalEndpoints() {
+    ConnectorUtils.validateEndpoint("pubsub.asia-east1.rep.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("pubsub.us-central1.rep.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("pubsub.europe-west1.rep.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("pubsub.northamerica-northeast1.rep.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("pubsub.southamerica-east1.rep.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("pubsub.australia-southeast1.rep.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("pubsub.me-central1.rep.googleapis.com:443");
+    ConnectorUtils.validateEndpoint("pubsub.africa-south1.rep.googleapis.com:443");
+  }
+
+  @Test
+  public void testInvalidEndpoints_uppercaseAndMixedCase() {
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("PUBSUB.GOOGLEAPIS.COM:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("PubSub.GoogleApis.Com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("ASIA-EAST1-PUBSUB.GOOGLEAPIS.COM:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("Asia-East1-Pubsub.Googleapis.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("PUBSUB.ASIA-EAST1.REP.GOOGLEAPIS.COM:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.Asia-East1.rep.googleapis.com:443"));
+  }
+
+  @Test
+  public void testInvalidEndpoints_nullOrEmpty() {
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint(null));
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint(""));
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("   "));
+  }
+
+  @Test
+  public void testInvalidEndpoints_missingPort() {
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("asia-east1-pubsub.googleapis.com"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.asia-east1.rep.googleapis.com"));
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:"));
+  }
+
+  @Test
+  public void testInvalidEndpoints_ssrfMetadataAndIps() {
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("169.254.169.254"));
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("169.254.169.254:80"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("http://169.254.169.254/computeMetadata/v1/"));
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("http://169.254.169.254:80"));
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("127.0.0.1"));
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("127.0.0.1:8080"));
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("10.0.0.1:443"));
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("192.168.1.1:443"));
+  }
+
+  @Test
+  public void testInvalidEndpoints_localhostAndArbitraryDomains() {
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("localhost"));
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("localhost:8080"));
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("evil.com:443"));
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("attacker.com:443"));
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("pubsub.attacker.com:443"));
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("googleapis.com:443"));
+    assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint("google.com:443"));
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("storage.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("compute.googleapis.com:443"));
+  }
+
+  @Test
+  public void testInvalidEndpoints_subdomainSpoofing() {
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com.evil.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("asia-east1-pubsub.googleapis.com.attacker.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.asia-east1.rep.googleapis.com.evil.com:443"));
+  }
+
+  @Test
+  public void testInvalidEndpoints_malformedRegionNames() {
+    // Missing region structure (no hyphen/numbers)
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("foo-pubsub.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("evil-pubsub.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.evil.rep.googleapis.com:443"));
+
+    // Numbers before hyphen / pure numeric
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("123-pubsub.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("123-456-pubsub.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.123.rep.googleapis.com:443"));
+
+    // Missing trailing region number
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("us-central-pubsub.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.us-central.rep.googleapis.com:443"));
+
+    // Multiple hyphens in region name
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("a-b-c-pubsub.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.a-b-c1.rep.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("us-central-1-pubsub.googleapis.com:443"));
+  }
+
+  @Test
+  public void testInvalidEndpoints_userInfo() {
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("user:pass@pubsub.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443@evil.com"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("user@pubsub.googleapis.com:443"));
+  }
+
+  @Test
+  public void testInvalidEndpoints_pathsQueryFragment() {
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443/"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443/v1/projects"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443/foo"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443?query=1"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443#frag"));
+  }
+
+  @Test
+  public void testInvalidEndpoints_schemes() {
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("https://pubsub.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("https://pubsub.googleapis.com"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("http://pubsub.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("http://pubsub.googleapis.com"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("//pubsub.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("ftp://pubsub.googleapis.com:443"));
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("file:///etc/passwd"));
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("javascript:alert(1)"));
+  }
+
+  @Test
+  public void testInvalidEndpoints_ports() {
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:0"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:65536"));
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:-5"));
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:abc"));
+    assertThrows(
+        ConfigException.class,
+        () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:443:443"));
+    assertThrows(
+        ConfigException.class, () -> ConnectorUtils.validateEndpoint(":443"));
+  }
+
+  @Test
+  public void testCpsEndpointValidatorToString() {
+    ConnectorUtils.CpsEndpointValidator validator = new ConnectorUtils.CpsEndpointValidator();
+    assertThat(validator.toString())
+        .isEqualTo(
+            "Official Cloud Pub/Sub endpoint in '<host>:<port>' format (e.g.,"
+                + " 'pubsub.googleapis.com:443')");
+  }
+
+  @Test
+  public void testErrorMessages() {
+    ConfigException nullEx =
+        assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint(null));
+    assertThat(nullEx.getMessage()).contains("Endpoint cannot be null or empty.");
+
+    ConfigException emptyEx =
+        assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint(""));
+    assertThat(emptyEx.getMessage()).contains("Endpoint cannot be null or empty.");
+
+    ConfigException noPortEx =
+        assertThrows(
+            ConfigException.class, () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com"));
+    assertThat(noPortEx.getMessage())
+        .contains(
+            "Endpoint must be in '<host>:<port>' format (e.g., 'pubsub.googleapis.com:443').");
+
+    ConfigException colonPrefixEx =
+        assertThrows(ConfigException.class, () -> ConnectorUtils.validateEndpoint(":443"));
+    assertThat(colonPrefixEx.getMessage())
+        .contains(
+            "Endpoint must be in '<host>:<port>' format (e.g., 'pubsub.googleapis.com:443').");
+
+    ConfigException hostEx =
+        assertThrows(
+            ConfigException.class, () -> ConnectorUtils.validateEndpoint("evil.com:443"));
+    assertThat(hostEx.getMessage())
+        .endsWith(": Host is not an allowed Cloud Pub/Sub endpoint.");
+    assertThat(hostEx.getMessage()).doesNotContain("Host 'evil.com'");
+
+    ConfigException portEx =
+        assertThrows(
+            ConfigException.class, () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:0"));
+    assertThat(portEx.getMessage()).contains("Port must be between 1 and 65535.");
+
+    ConfigException portNotNumberEx =
+        assertThrows(
+            ConfigException.class,
+            () -> ConnectorUtils.validateEndpoint("pubsub.googleapis.com:invalid"));
+    assertThat(portNotNumberEx.getMessage()).contains("Port must be between 1 and 65535.");
+  }
+}

--- a/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
+++ b/src/test/java/com/google/pubsub/kafka/common/ConnectorUtilsTest.java
@@ -17,6 +17,7 @@ package com.google.pubsub.kafka.common;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
+
 import java.util.Arrays;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.Test;


### PR DESCRIPTION
Introduce the option to validate that `cps.endpoint` is an official Cloud Pub/Sub endpoint (`pubsub.googleapis.com`, `<region>-pubsub.googleapis.com`, and `pubsub.<region>.rep.googleapis.com`).

Validation is enabled when the environment variable `CPS_ENFORCE_OFFICIAL_ENDPOINTS` is set to `true`.